### PR TITLE
fix: There should be a linebreak after this element (array-element-newline)

### DIFF
--- a/test.js
+++ b/test.js
@@ -71,10 +71,12 @@ test('editor - WebStorm', t => {
 test('editor - TextMate', t => {
 	t.deepEqual(m.make(fixtureFiles, {editor: 'textmate'}), {
 		bin: 'mate',
-		args: [
-			'--line', '10:20', 'unicorn.js',
-			'--line', '43:4', 'rainbow.js'
-		],
+		args: ['--line',
+			'10:20',
+			'unicorn.js',
+			'--line',
+			'43:4',
+			'rainbow.js'],
 		isTerminalEditor: false
 	});
 });
@@ -82,10 +84,10 @@ test('editor - TextMate', t => {
 test('editor - Vim', t => {
 	t.deepEqual(m.make(fixtureFiles, {editor: 'vim'}), {
 		bin: 'vim',
-		args: [
-			'+call cursor(10, 20)', 'unicorn.js',
-			'+call cursor(43, 4)', 'rainbow.js'
-		],
+		args: ['+call cursor(10, 20)',
+			'unicorn.js',
+			'+call cursor(43, 4)',
+			'rainbow.js'],
 		isTerminalEditor: true
 	});
 });
@@ -93,10 +95,10 @@ test('editor - Vim', t => {
 test('editor - NeoVim', t => {
 	t.deepEqual(m.make(fixtureFiles, {editor: 'neovim'}), {
 		bin: 'nvim',
-		args: [
-			'+call cursor(10, 20)', 'unicorn.js',
-			'+call cursor(43, 4)', 'rainbow.js'
-		],
+		args: ['+call cursor(10, 20)',
+			'unicorn.js',
+			'+call cursor(43, 4)',
+			'rainbow.js'],
 		isTerminalEditor: true
 	});
 });
@@ -104,10 +106,8 @@ test('editor - NeoVim', t => {
 test('editor - IntelliJ IDEA', t => {
 	t.deepEqual(m.make(fixtureFiles, {editor: 'intellij'}), {
 		bin: 'idea',
-		args: [
-			'unicorn.js:10',
-			'rainbow.js:43'
-		],
+		args: ['unicorn.js:10',
+			'rainbow.js:43'],
 		isTerminalEditor: false
 	});
 });


### PR DESCRIPTION
npm run test `xo && ava` is not work.

```
toshiki@aoi-local% npm run test
> open-editor@1.2.0 test /home/toshiki/work/open-editor
> xo && ava
                                                                                                             
                                                                                                             
  test.js:75:13 
  ✖  75:13  There should be a linebreak after this element.  array-element-newline 
  ✖  75:22  There should be a linebreak after this element.  array-element-newline 
  ✖  76:13  There should be a linebreak after this element.  array-element-newline  
  ✖  76:21  There should be a linebreak after this element.  array-element-newline
  ✖  86:27  There should be a linebreak after this element.  array-element-newline
  ✖  87:26  There should be a linebreak after this element.  array-element-newline
  ✖  97:27  There should be a linebreak after this element.  array-element-newline
  ✖  98:26  There should be a linebreak after this element.  array-element-newline

  8 errors
```

I fixed test.js and work correctly.
```
toshiki@aoi-local% npm run test
> open-editor@1.2.0 test /home/toshiki/work/open-editor
> xo && ava

  10 tests passed
```