### PR TITLE
fix: windows shell

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: node_js
+os:
+  - windows
+  - linux
+
 node_js:
   - '12'
   - '10'

--- a/index.js
+++ b/index.js
@@ -57,6 +57,7 @@ module.exports = (files, options) => {
 
 	const subProcess = childProcess.spawn(result.binary, result.arguments, {
 		detached: true,
+		shell: process.platform === 'win32',
 		stdio
 	});
 


### PR DESCRIPTION
The snippet in `example.js` doesn't work on windows platform with this setup:
(from git-bash)
```
echo $PATH
/mingw64/bin:/usr/local/bin:/usr/bin:/bin:/c/Program Files/Microsoft VS Code/bin
echo $EDITOR
code
echo $COMSPEC
C:\WINDOWS\system32\cmd.exe
```

For what I read from [docs](https://nodejs.org/api/child_process.html#child_process_spawning_bat_and_cmd_files_on_windows), this is caused by windows that require some adjustments on the `spawn` command in order to works properly:
- based on the editor, there should be a "binary windows" that could be:
`childProcess.spawn(`${result.binary}.cmd` or `childProcess.spawn(`${result.binary}.exe`
- the easiest is this PR, that add `shell: process.platform === 'win32'` parameter so the command will be executed in a standalone shall

A related issue on node.js (since vscode is an electron app)
https://github.com/nodejs/node/issues/15217


I would appreciate your thought about this PR.
Thank you very much