### PR TITLE
Improve Windows compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,30 +54,28 @@ const make = (files, options = {}) => {
 module.exports = (files, options) => {
 	const result = make(files, options);
 	const stdio = result.isTerminalEditor ? 'inherit' : 'ignore';
-	(async () => {
-		const subProcess = execa(result.binary, result.arguments, {
-			detached: true,
-			stdio
+	const subProcess = execa(result.binary, result.arguments, {
+		detached: true,
+		stdio
+	});
+
+	// Fallback
+	subProcess.on('error', () => {
+		const result = make(files, {
+			...options,
+			editor: ''
 		});
 
-		// Fallback
-		subProcess.on('error', () => {
-			const result = make(files, {
-				...options,
-				editor: ''
-			});
-
-			for (const file of result.arguments) {
-				open(file);
-			}
-		});
-
-		if (result.isTerminalEditor) {
-			subProcess.on('exit', process.exit);
-		} else {
-			subProcess.unref();
+		for (const file of result.arguments) {
+			open(file);
 		}
-	})();
+	});
+
+	if (result.isTerminalEditor) {
+		subProcess.on('exit', process.exit);
+	} else {
+		subProcess.unref();
+	}
 };
 
 module.exports.make = make;

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 	],
 	"dependencies": {
 		"env-editor": "^0.4.0",
+		"execa": "^5.0.0",
 		"line-column-path": "^2.0.0",
 		"open": "^6.2.0"
 	},

--- a/test.js
+++ b/test.js
@@ -70,7 +70,7 @@ test('editor - VS Code', t => {
 
 test('editor - WebStorm', t => {
 	t.deepEqual(openEditor.make(fixtureFiles, {editor: 'webstorm'}), {
-		binary: 'wstorm',
+		binary: 'webstorm',
 		arguments: [
 			'unicorn.js:10',
 			'rainbow.js:43'


### PR DESCRIPTION
Fixes #13 

This PR takes into account https://github.com/sindresorhus/open-editor/pull/9#issuecomment-497230452 and just/lazily/simply switch from child_process to execa.

I'm really not knowledgeable about processes management and such, so please let me know if anything needs changing.

Before proposing this PR, I wanted to make sure `npm test` run OK and since my installation ran on `env-editor@0.4.1`, I just fixed the `webstorm` binary typo which was changed in https://github.com/sindresorhus/env-editor/commit/65f76c42b8dd1b7ddddd3680b1ad2f1b54c1d004

