### PR TITLE
Wait for editor process to finish

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,14 @@ export interface Options {
 	Wait until the editor is closed.
 
 	@default false
+	
+	@example
+	```
+	import openEditor from 'open-editor';
+	
+	await openEditor(['unicorn.js:5:3'], {wait: true});
+	console.log('File was closed');
+	```
 	*/
 	readonly wait?: boolean;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -40,8 +40,6 @@ Open the given files in the user's editor at specific line and column if support
 
 @param files - Items should be in the format `foo.js:1:5` or `{file: 'foo.js', line: 1: column: 5}`.
 
-@param {boolean} [options.wait=false] - Wait until the editor is closed (default: false).
-
 @returns Promise<void> - If options.wait is true, the returned promise resolves as soon as the editor closes. Otherwise it resolves when the editor starts.
 
 @example

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ export interface Options {
 	readonly editor?: string;
 
 	/**
-	Wheather you want to wait for the editor to quit.
+	Whether you want to wait for the editor to quit.
 
 	@default false
 	*/
@@ -40,7 +40,7 @@ Open the given files in the user's editor at specific line and column if support
 
 @param files - Items should be in the format `foo.js:1:5` or `{file: 'foo.js', line: 1: column: 5}`.
 
-@returns void or Promise<void> - If options.wait is true, a promise is returned which resolves as soon as the editor closes.
+@returns void | Promise<void> - If options.wait is true, a promise is returned which resolves as soon as the editor closes.
 
 @example
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,13 @@ export interface Options {
 	__Only use this option if you really have to.__ Can be useful if you want to force a specific editor or implement your own auto-detection.
 	*/
 	readonly editor?: string;
+
+	/**
+	Wheather you want to wait for the editor to quit.
+
+	Default: false
+	*/
+	readonly wait?: boolean;
 }
 
 export interface EditorInfo {
@@ -33,6 +40,8 @@ Open the given files in the user's editor at specific line and column if support
 
 @param files - Items should be in the format `foo.js:1:5` or `{file: 'foo.js', line: 1: column: 5}`.
 
+@returns void or Promise<void> - If options.wait is true, a promise is returned which resolves as soon as the editor closes.
+
 @example
 ```
 import openEditor from 'open-editor';
@@ -50,7 +59,7 @@ openEditor([
 ]);
 ```
 */
-export default function openEditor(files: readonly PathLike[], options?: Options): void;
+export default function openEditor(files: readonly PathLike[], options?: Options): void|Promise<void>;
 
 /**
 Same as `openEditor()`, but returns an object with the binary name, arguments, and a flag indicating whether the editor runs in the terminal.

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ export interface Options {
 	/**
 	Wheather you want to wait for the editor to quit.
 
-	Default: false
+	@default false
 	*/
 	readonly wait?: boolean;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -59,7 +59,7 @@ openEditor([
 ]);
 ```
 */
-export default function openEditor(files: readonly PathLike[], options?: Options): void|Promise<void>;
+export default function openEditor(files: readonly PathLike[], options?: Options): void | Promise<void>;
 
 /**
 Same as `openEditor()`, but returns an object with the binary name, arguments, and a flag indicating whether the editor runs in the terminal.

--- a/index.d.ts
+++ b/index.d.ts
@@ -65,9 +65,6 @@ openEditor([
 openEditor([
 	'unicorn.js:5:3',
 ]);
-
-await openEditor(['unicorn.js:5:3'], {wait: true});
-console.log('File was closed');
 ```
 */
 export default function openEditor(files: readonly PathLike[], options?: Options): Promise<void>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,11 +14,11 @@ export interface Options {
 	Wait until the editor is closed.
 
 	@default false
-	
+
 	@example
 	```
 	import openEditor from 'open-editor';
-	
+
 	await openEditor(['unicorn.js:5:3'], {wait: true});
 	console.log('File was closed');
 	```

--- a/index.d.ts
+++ b/index.d.ts
@@ -62,7 +62,6 @@ openEditor([
 
 await openEditor(['unicorn.js:5:3'], {wait: true});
 console.log('File was closed');
-
 ```
 */
 export default function openEditor(files: readonly PathLike[], options?: Options): Promise<void>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,11 +36,13 @@ export interface EditorInfo {
 }
 
 /**
-Open the given files in the user's editor at specific line and column if supported by the editor. It does not wait for the editor to start or quit.
+Open the given files in the user's editor at specific line and column if supported by the editor. It does not wait for the editor to start or quit  unless you specify `wait: true` in the options.
 
 @param files - Items should be in the format `foo.js:1:5` or `{file: 'foo.js', line: 1: column: 5}`.
 
-@returns void | Promise<void> - If options.wait is true, a promise is returned which resolves as soon as the editor closes.
+@param {boolean} [options.wait=false] - Wait until the editor is closed (default: false).
+
+@returns Promise<void> - If options.wait is true, a promise is returned which resolves as soon as the editor closes.
 
 @example
 ```
@@ -57,6 +59,10 @@ openEditor([
 openEditor([
 	'unicorn.js:5:3',
 ]);
+
+await openEditor(['unicorn.js:5:3'], {wait: true});
+console.log('File was closed');
+
 ```
 */
 export default function openEditor(files: readonly PathLike[], options?: Options): void | Promise<void>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,7 +36,7 @@ export interface EditorInfo {
 }
 
 /**
-Open the given files in the user's editor at specific line and column if supported by the editor. It does not wait for the editor to start or quit  unless you specify `wait: true` in the options.
+Open the given files in the user's editor at specific line and column if supported by the editor. It does not wait for the editor to start or quit unless you specify `wait: true` in the options.
 
 @param files - Items should be in the format `foo.js:1:5` or `{file: 'foo.js', line: 1: column: 5}`.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -65,7 +65,7 @@ console.log('File was closed');
 
 ```
 */
-export default function openEditor(files: readonly PathLike[], options?: Options): void | Promise<void>;
+export default function openEditor(files: readonly PathLike[], options?: Options): Promise<void>;
 
 /**
 Same as `openEditor()`, but returns an object with the binary name, arguments, and a flag indicating whether the editor runs in the terminal.

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ export interface Options {
 	readonly editor?: string;
 
 	/**
-	Whether you want to wait for the editor to quit.
+	Wait until the editor is closed.
 
 	@default false
 	*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,7 +42,7 @@ Open the given files in the user's editor at specific line and column if support
 
 @param {boolean} [options.wait=false] - Wait until the editor is closed (default: false).
 
-@returns Promise<void> - If options.wait is true, a promise is returned which resolves as soon as the editor closes.
+@returns Promise<void> - If options.wait is true, the returned promise resolves as soon as the editor closes. Otherwise it resolves when the editor starts.
 
 @example
 ```

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ export function getEditorInfo(files, options = {}) {
 	};
 }
 
-export default function openEditor(files, options) {
+export default async function openEditor(files, options) {
 	const result = getEditorInfo(files, options);
 	const stdio = result.isTerminalEditor ? 'inherit' : 'ignore';
 

--- a/index.js
+++ b/index.js
@@ -21,23 +21,42 @@ export function getEditorInfo(files, options = {}) {
 
 		if (['sublime', 'atom', 'vscode', 'vscodium'].includes(editor.id)) {
 			editorArguments.push(stringifyLineColumnPath(parsed));
+			if (options.wait) {
+				editorArguments.push('--wait');
+			}
+
 			continue;
 		}
 
 		if (['webstorm', 'intellij'].includes(editor.id)) {
 			editorArguments.push(stringifyLineColumnPath(parsed, {column: false}));
+			if (options.wait) {
+				editorArguments.push('--wait');
+			}
+
 			continue;
 		}
 
 		if (editor.id === 'textmate') {
-			editorArguments.push('--line', stringifyLineColumnPath(parsed, {
-				file: false,
-			}), parsed.file);
+			editorArguments.push(
+				'--line',
+				stringifyLineColumnPath(parsed, {
+					file: false,
+				}),
+				parsed.file,
+			);
+			if (options.wait) {
+				editorArguments.push('-w');
+			}
+
 			continue;
 		}
 
 		if (['vim', 'neovim'].includes(editor.id)) {
-			editorArguments.push(`+call cursor(${parsed.line}, ${parsed.column})`, parsed.file);
+			editorArguments.push(
+				`+call cursor(${parsed.line}, ${parsed.column})`,
+				parsed.file,
+			);
 			continue;
 		}
 
@@ -71,6 +90,12 @@ export default function openEditor(files, options) {
 			open(file);
 		}
 	});
+
+	if (options.wait) {
+		return new Promise(resolve => {
+			subprocess.on('exit', resolve);
+		});
+	}
 
 	if (result.isTerminalEditor) {
 		subprocess.on('exit', process.exit);

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ export function getEditorInfo(files, options = {}) {
 			);
 
 			if (options.wait) {
-				editorArguments.push('-w');
+				editorArguments.push('--wait');
 			}
 
 			continue;

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ export function getEditorInfo(files, options = {}) {
 
 		if (['sublime', 'atom', 'vscode', 'vscodium'].includes(editor.id)) {
 			editorArguments.push(stringifyLineColumnPath(parsed));
+
 			if (options.wait) {
 				editorArguments.push('--wait');
 			}
@@ -30,6 +31,7 @@ export function getEditorInfo(files, options = {}) {
 
 		if (['webstorm', 'intellij'].includes(editor.id)) {
 			editorArguments.push(stringifyLineColumnPath(parsed, {column: false}));
+
 			if (options.wait) {
 				editorArguments.push('--wait');
 			}
@@ -45,6 +47,7 @@ export function getEditorInfo(files, options = {}) {
 				}),
 				parsed.file,
 			);
+
 			if (options.wait) {
 				editorArguments.push('-w');
 			}
@@ -57,6 +60,7 @@ export function getEditorInfo(files, options = {}) {
 				`+call cursor(${parsed.line}, ${parsed.column})`,
 				parsed.file,
 			);
+
 			continue;
 		}
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,7 +1,7 @@
 import {expectType} from 'tsd';
 import openEditor, {getEditorInfo, EditorInfo} from './index.js';
 
-openEditor([
+void openEditor([
 	'unicorn.js:5:3',
 	{
 		file: 'readme.md',
@@ -10,7 +10,7 @@ openEditor([
 	},
 ]);
 
-openEditor(
+void openEditor(
 	[
 		'unicorn.js:5:3',
 		{

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,11 @@ openEditor([
 openEditor([
 	'unicorn.js:5:3',
 ]);
+
+await openEditor([
+	'unicorn.js:5:3',
+], { wait: true });
+console.log('file was closed');
 ```
 
 ## API
@@ -55,6 +60,13 @@ Items should be in the format `foo.js:1:5` or `{file: 'foo.js', line: 1: column:
 #### options
 
 Type: `object`
+
+##### wait
+
+Type: `boolean`\
+Default: false
+
+Wait until the edit process is finished (editor is closed).
 
 ##### editor
 

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,9 @@ openEditor([
 openEditor([
 	'unicorn.js:5:3',
 ]);
+
+await openEditor(['unicorn.js:5:3'], {wait: true});
+console.log('File was closed');
 ```
 
 ## API

--- a/readme.md
+++ b/readme.md
@@ -38,11 +38,6 @@ openEditor([
 openEditor([
 	'unicorn.js:5:3',
 ]);
-
-await openEditor([
-	'unicorn.js:5:3',
-], { wait: true });
-console.log('file was closed');
 ```
 
 ## API
@@ -66,7 +61,15 @@ Type: `object`
 Type: `boolean`\
 Default: false
 
-Wait until the edit process is finished (editor is closed).
+Wait until the editor is closed.
+
+```js
+import openEditor from 'open-editor';
+
+await openEditor(['unicorn.js:5:3'], {wait: true});
+
+console.log('File was closed');
+```
 
 ##### editor
 

--- a/readme.md
+++ b/readme.md
@@ -38,9 +38,6 @@ openEditor([
 openEditor([
 	'unicorn.js:5:3',
 ]);
-
-await openEditor(['unicorn.js:5:3'], {wait: true});
-console.log('File was closed');
 ```
 
 ## API

--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ Type: `object`
 ##### wait
 
 Type: `boolean`\
-Default: false
+Default: `false`
 
 Wait until the editor is closed.
 

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ openEditor([
 
 ### openEditor(files, options?)
 
-Open the given files in the user's editor at specific line and column if supported by the editor. It does not wait for the editor to start or quit.
+Open the given files in the user's editor at specific line and column if supported by the editor. It does not wait for the editor to start or quit unless you specify `wait: true` in the options.
 
 #### files
 


### PR DESCRIPTION
Add option `wait` so we know when the edit process is finished.

I hope you are fine with this feature. If not, just tell me what I can do better.

Thank you for providing great open source software!

This builds up on my previous PR: https://github.com/sindresorhus/open-editor/pull/16

Fixes #12