### PR TITLE
add `openEditor` default options

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ export function getEditorInfo(files, options = {}) {
 	};
 }
 
-export default async function openEditor(files, options) {
+export default async function openEditor(files, options = {}) {
 	const result = getEditorInfo(files, options);
 	const stdio = result.isTerminalEditor ? 'inherit' : 'ignore';
 


### PR DESCRIPTION
`openEditor` uses  `options.wait`, but since `options` could be `undefined`, line 98 throws an error.

```javascript
if (options.wait) {
  return new Promise(resolve => {
    subprocess.on('exit', resolve);
  });
}
```

and, I found `openEditor` takes `options` parameter as optional, I add default value.

I'm uncertain about the appropriate default value for `options`. So, I've utilized an empty object (`{}`), which can alternatively be used as `{ wait: false }` for specificity.

please let me know what default value would be good. :)

